### PR TITLE
Response window are now populated on web exceptions

### DIFF
--- a/Drexyia/Drexyia.WebSvc.Process/WebSvcAsync/EventParams/ExceptionAsyncArgs.cs
+++ b/Drexyia/Drexyia.WebSvc.Process/WebSvcAsync/EventParams/ExceptionAsyncArgs.cs
@@ -9,9 +9,12 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using Drexyia.WebSvc.Process.WebSvcAsync.Result;
 
 namespace Drexyia.WebSvc.Process.WebSvcAsync.EventParams {
     public class ExceptionAsyncArgs : AsyncArgs {
+
+        public CallAsyncResult Result { get; set; }
 
         public Exception Ex {
             get;

--- a/Drexyia/Drexyia.WebSvc.Process/WebSvcAsync/Operations/AsyncOp.cs
+++ b/Drexyia/Drexyia.WebSvc.Process/WebSvcAsync/Operations/AsyncOp.cs
@@ -171,8 +171,6 @@ namespace Drexyia.WebSvc.Process.WebSvcAsync.Operations {
                 var streamReader = new StreamReader(ex.Response.GetResponseStream());
                 string body = streamReader.ReadToEnd();
 
-
-                
                 string status = ((HttpWebResponse)ex.Response).StatusCode.ToString();
                 Dictionary<string, string> headers = new Dictionary<string, string>();
                 foreach (string key in ex.Response.Headers.Keys)
@@ -195,14 +193,5 @@ namespace Drexyia.WebSvc.Process.WebSvcAsync.Operations {
             //in the event of user cancel the timout thread must be stopped
             _timeoutObject.Stop();
         }
-
-
-
-
-
-
-
-
-
     }
 }

--- a/WsdlUI/WsdlUI.App.UI/UserControls/uc_Wm.cs
+++ b/WsdlUI/WsdlUI.App.UI/UserControls/uc_Wm.cs
@@ -104,6 +104,8 @@ namespace WsdlUI.App.UI.UserControls {
 
             }));
 
+            Invoke((MethodInvoker)(() => uc_wm_response1.PopulateForm(e.Result)));
+
             SetReady("request end");
 
         }


### PR DESCRIPTION
Added response to the GUI even when you get webexceptions, which can be very useful. Raw output from services are your best friend when debugging.

I do realise the reading of the response (seen in AsyncOp.cs:171 and onwards) is duplication from CallAsyncOp.cs:100. I guess this could/shold be moved out somewhere else, but I didn't want to touch the basic structures too much. I'd be happy to do so if need be though.
